### PR TITLE
Bug into regex allow any character between numbers

### DIFF
--- a/ngx-csv.ts
+++ b/ngx-csv.ts
@@ -185,7 +185,7 @@ export class ngxCsv {
      * @param {any} input
      */
     static isFloat(input: any) {
-        const regex = /^([+|-]?\d+.\d+\b)/;
+        const regex = /^([+|-]?\d+\.\d+\b)/;
         return regex.exec(input) !== null;
     }
 }


### PR DESCRIPTION
The regular expression was malfunctioning.
Some dates were treated as floats.
![imagen](https://user-images.githubusercontent.com/20474411/82737199-6f9ff880-9d2f-11ea-8fd1-c465f8c1cab6.png)

![imagen](https://user-images.githubusercontent.com/20474411/82737211-91997b00-9d2f-11ea-891f-165a2f1926aa.png)

